### PR TITLE
Update to work with Jekyll 3.0.

### DIFF
--- a/jekyll-rdfa.gemspec
+++ b/jekyll-rdfa.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rdf',       '~> 1.1'
   s.add_runtime_dependency 'rdf-turtle', '~> 1.1'
   s.add_runtime_dependency 'rdf-rdfa',  '~> 1.1'
-  s.add_runtime_dependency 'jekyll',    '~> 2.5'
+  s.add_runtime_dependency 'jekyll',    '>= 3.0'
 end

--- a/lib/jekyll-rdfa.rb
+++ b/lib/jekyll-rdfa.rb
@@ -14,10 +14,10 @@ module Jekyll
       require 'rdf/turtle'
       require 'rdf/rdfa'
 
-      converter = site.getConverterImpl(Jekyll::Converters::Markdown)
+      converter = site.find_converter_instance(Jekyll::Converters::Markdown)
 
       graph = RDF::Graph.new
-      site.posts.each do |post|
+      site.posts.docs.each do |post|
         html = converter.convert(post.content)
 
         attribs = {}


### PR DESCRIPTION
- Use renamed find_converter_instance.
- Call Collection#each on the #docs array directly, to avoid deprecation warning.

These changes are not backwards compatible, so this also bumps the version requirement for the Jekyll dependency.  Could include some version checks to make this backwards compatible.
