### PR TITLE
Parse RDF on all generated HTML.

### DIFF
--- a/jekyll-rdfa.gemspec
+++ b/jekyll-rdfa.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rdf',       '~> 1.1'
   s.add_runtime_dependency 'rdf-turtle', '~> 1.1'
   s.add_runtime_dependency 'rdf-rdfa',  '~> 1.1'
+  s.add_runtime_dependency 'nokogiri', '~> 1.6'
   s.add_runtime_dependency 'jekyll',    '>= 3.0'
 end

--- a/lib/jekyll-rdfa.rb
+++ b/lib/jekyll-rdfa.rb
@@ -14,43 +14,11 @@ module Jekyll
       require 'rdf/turtle'
       require 'rdf/rdfa'
 
-      converter = site.find_converter_instance(Jekyll::Converters::Markdown)
-
       graph = RDF::Graph.new
-      site.posts.docs.each do |post|
-        html = converter.convert(post.content)
 
-        attribs = {}
-        attribs[:vocab] = post.data["vocab"] if post.data.member? "vocab"
-
-        needs_typeof = false
-        if post.data.member? "resource"
-          attribs[:resource] = post.data["resource"]
-          needs_typeof = true
-        end
-        if post.data.member? "about"
-          attribs[:about] = post.data["about"]
-          needs_typeof = true
-        end
-        if post.data.member? "typeof" and needs_typeof
-          attribs[:typeof] = post.data["typeof"]
-        end
-
-        if post.data.member? "prefix"
-          prefixes = post.data["prefix"]
-                     .to_a.map { |key, value| "#{key}: #{value}" }
-                     .join " "
-          attribs[:prefix] = prefixes
-        end
-
-        unless attribs.empty?
-          markup = attribs
-                   .to_a
-                   .map { |key, value| " #{key}='#{value}'"}
-                   .join ""
-          html = "<div#{markup}>#{html}</div>"
-        end
-        count = 0
+      count = 0
+      site.docs_to_write.each do |document|
+        html = Jekyll::Renderer.new(site, document, site.site_payload).run
         RDF::Reader.for(:rdfa).new(html) do |reader|
           reader.each_statement do |statement|
             graph << statement


### PR DESCRIPTION
Instead of looping through site posts and rendering only the markdown
content of the posts, this change reads the full HTML output for all
site documents, and parses them for RDFa data.

This also has the advantage of not relying on specific YAML frontmatter
keys for things like vocab and resource. Authors can structure their
YAML however they prefer, but it does mean that site templates will need
to include RDFa attributes for things like vocab, resource, typeof, and
prefixes. I think this will allow for more flexibility.

Also adds a dependency for Nokogiri, since the rdf-rdfa project
recommends it for parsing HTML.
